### PR TITLE
Make the jump to IP-MASQ rule to take precedence

### DIFF
--- a/cmd/ip-masq-agent/ip-masq-agent.go
+++ b/cmd/ip-masq-agent/ip-masq-agent.go
@@ -280,7 +280,7 @@ func postroutingJumpComment() string {
 }
 
 func (m *MasqDaemon) ensurePostroutingJump() error {
-	if _, err := m.iptables.EnsureRule(utiliptables.Append, utiliptables.TableNAT, utiliptables.ChainPostrouting,
+	if _, err := m.iptables.EnsureRule(utiliptables.Prepend, utiliptables.TableNAT, utiliptables.ChainPostrouting,
 		"-m", "comment", "--comment", postroutingJumpComment(),
 		"-m", "addrtype", "!", "--dst-type", "LOCAL", "-j", string(masqChain)); err != nil {
 		return fmt.Errorf("failed to ensure that %s chain %s jumps to MASQUERADE: %v", utiliptables.TableNAT, masqChain, err)


### PR DESCRIPTION
Currently the IP-MASQ jump rule is behind the MASQUARADE jump
rule, ending up with no effect on nonMasqueradeCIDRs.
This commit puts the rule at the top of POSTROUTING chain
so it takes precedence over the default masquarade rules.