### PR TITLE
Update manifest to work with k8s 1.16

### DIFF
--- a/ip-masq-agent.yaml
+++ b/ip-masq-agent.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: ip-masq-agent
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      k8s-app: ip-masq-agent
   template:
     metadata:
       labels:


### PR DESCRIPTION
Kubernetes 1.16 dropped support for DaemonSets in extensions/v1beta1, and apps/v1 now expects a non-empty selector.