### PR TITLE
Remove inactive members from OWNERS and SECURITY_CONTACTS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,6 @@ reviewers:
   - mtaufen
   - thockin
   - bowei
-  - dnardo
   - mrhohn
   - varunmar
   - grayluck
@@ -10,5 +9,6 @@ approvers:
   - mtaufen
   - thockin
   - bowei
-  - dnardo
   - mrhohn
+emeritus_approvers:
+  - dnardo

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -11,4 +11,3 @@
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
 thockin
-dnardo


### PR DESCRIPTION
For kubernetes/org#2013

As a part of cleaning up inactive members (who haven't been active since
the release of v1.11) from OWNERS, this commit removes dnardo from
the OWNERS and SECURITY_CONTACTS files.

/assign @MrHohn 
cc @mrbobbytables @dnardo 