### PR TITLE
Support an optional SNAT target instead of MASQUERADE

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ By default, the agent is configured to treat the three private IP ranges specifi
 
 By default, the agent is configured to reload its configuration from the `/etc/config/ip-masq-agent` file in its container every 60 seconds.
 
-The agent configuration file should be written in yaml or json syntax, and may contain three optional keys:
+The agent configuration file should be written in yaml or json syntax, and may contain these optional keys:
 - `nonMasqueradeCIDRs []string`: A list strings in CIDR notation that specify the non-masquerade ranges.
 - `masqLinkLocal bool`: Whether to masquerade traffic to `169.254.0.0/16`. False by default.
 - `masqLinkLocalIPv6 bool`: Whether to masquerade traffic to `fe80::/10`. False by default.
 - `resyncInterval string`: The interval at which the agent attempts to reload config from disk. The syntax is any format accepted by Go's [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration) function.
+- `snatTarget string`: An IPv4 address to SNAT outbound traffic to instead of MASQUERADE to the node IP. Not set by default.
 
 The agent will look for a config file in its container at `/etc/config/ip-masq-agent`. This file can be provided via a `ConfigMap`, plumbed into the container via a `ConfigMapVolumeSource`. As a result, the agent can be reconfigured in a live cluster by creating or editing this `ConfigMap`.
 

--- a/cmd/ip-masq-agent/ip-masq-agent.go
+++ b/cmd/ip-masq-agent/ip-masq-agent.go
@@ -243,10 +243,8 @@ func (c *MasqConfig) validate() error {
 		}
 	}
 	// check if SNAT target is a valid ip
-	if c.SnatTarget != "" {
-		if err := validateIP(c.SnatTarget); err != nil {
-			return err
-		}
+	if c.SnatTarget != "" && net.ParseIP(c.SnatTarget) == nil {
+		return fmt.Errorf("SnatTarget is not a valid IP (%q)", c.SnatTarget)
 	}
 	return nil
 }
@@ -263,16 +261,6 @@ func validateCIDR(cidr string) error {
 	// alignment test
 	if !ip.Equal(ipnet.IP) {
 		return fmt.Errorf(cidrAlignErrFmt, cidr, ip, ipnet.String())
-	}
-	return nil
-}
-
-const ipParseErrFmt = "IP %q could not be parsed"
-
-func validateIP(ip string) error {
-	// parse test
-	if net.ParseIP(ip) == nil {
-		return fmt.Errorf(ipParseErrFmt, ip)
 	}
 	return nil
 }

--- a/cmd/ip-masq-agent/ip-masq-agent_test.go
+++ b/cmd/ip-masq-agent/ip-masq-agent_test.go
@@ -104,7 +104,7 @@ var validateConfigTests = []struct {
 	// Misaligned CIDR
 	{&MasqConfig{NonMasqueradeCIDRs: []string{"10.0.0.1/8"}}, fmt.Errorf(cidrAlignErrFmt, "10.0.0.1/8", "10.0.0.1", "10.0.0.0/8")},
 	// invalid SNAT target IP
-	{&MasqConfig{SnatTarget: "foo"}, fmt.Errorf(ipParseErrFmt, "foo")},
+	{&MasqConfig{SnatTarget: "foo"}, fmt.Errorf("SnatTarget is not a valid IP (%q)", "foo")},
 }
 
 // tests the MasqConfig.validate method


### PR DESCRIPTION
Adds an optional parameter "SnatTarget". When set to an ip address, ip-masq-agent will create an SNAT rule instead of MASQUERADE for outbound traffic. This fixes #56 