### PR TITLE
Masquerade exception list on large non-masquerade CIDRs blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ By default, the agent is configured to treat the three private IP ranges specifi
 
 By default, the agent is configured to reload its configuration from the `/etc/config/ip-masq-agent` file in its container every 60 seconds.
 
-The agent configuration file should be written in yaml or json syntax, and may contain three optional keys:
+The agent configuration file should be written in yaml or json syntax, and may contain these optional keys:
+- `masqueradeExceptionCIDRs []string`: A list strings in CIDR notation that explicity masquerade before any other range evaluated.
 - `nonMasqueradeCIDRs []string`: A list strings in CIDR notation that specify the non-masquerade ranges.
 - `masqLinkLocal bool`: Whether to masquerade traffic to `169.254.0.0/16`. False by default.
 - `masqLinkLocalIPv6 bool`: Whether to masquerade traffic to `fe80::/10`. False by default.


### PR DESCRIPTION
This PR adds functionality to allow masquerade small ranges exception in large non-masquerade CIDRs. 
Eg: do not masquerade 10.0.0.0/8, but masquerade sub range 10.20.20.0/24 