### PR TITLE
Bump up the iptables base image to pick up CVE fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,16 +50,16 @@ endif
 
 # Set default base image dynamically for each arch
 ifeq ($(ARCH),amd64)
-    BASEIMAGE?=k8s.gcr.io/debian-iptables-amd64:v12.0.1
+    BASEIMAGE?=k8s.gcr.io/build-image/debian-iptables-amd64:buster-v1.7.0
 endif
 ifeq ($(ARCH),arm)
-    BASEIMAGE?=k8s.gcr.io/debian-iptables-arm:v12.0.1
+    BASEIMAGE?=k8s.gcr.io/build-image/debian-iptables-arm:buster-v1.7.0
 endif
 ifeq ($(ARCH),arm64)
-    BASEIMAGE?=k8s.gcr.io/debian-iptables-arm64:v12.0.1
+    BASEIMAGE?=k8s.gcr.io/build-image/debian-iptables-arm64:buster-v1.7.0
 endif
 ifeq ($(ARCH),ppc64le)
-    BASEIMAGE?=k8s.gcr.io/debian-iptables-ppc64le:v12.0.1
+    BASEIMAGE?=k8s.gcr.io/build-image/debian-iptables-ppc64le:buster-v1.7.0
 endif
 
 IMAGE := $(REGISTRY)/$(BIN)-$(ARCH)


### PR DESCRIPTION
Updating to use the latest base image available from https://github.com/kubernetes/release/blob/master/images/build/debian-iptables/Makefile.

/assign @varunmar 