### PR TITLE
updated link for instructions to add a dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,4 +23,4 @@ Follow either of the two links above to access the appropriate CLA and instructi
 
 ### Adding dependencies
 
-If your patch depends on new packages, add that package with [`godep`](https://github.com/tools/godep). Follow the [instructions to add a dependency](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md#godep-and-dependency-management).
+If your patch depends on new packages, add that package with [`godep`](https://github.com/tools/godep). Follow the [instructions to add a dependency](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/godep.md#using-godep-to-manage-dependencies).


### PR DESCRIPTION
Link for " instructions to add a dependency" was outdated and broken in https://github.com/kundan2707/ip-masq-agent/blob/master/CONTRIBUTING.md