### PR TITLE
Update manifest to point to the prod 2.7.0 image.

### DIFF
--- a/ip-masq-agent.yaml
+++ b/ip-masq-agent.yaml
@@ -15,7 +15,7 @@ spec:
       hostNetwork: true
       containers:
       - name: ip-masq-agent
-        image: gcr.io/k8s-staging-networking/ip-masq-agent:v2.7.0
+        image: k8s.gcr.io/networking/ip-masq-agent:v2.7.0
         securityContext:
           privileged: false
           capabilities:


### PR DESCRIPTION
This fixes https://github.com/kubernetes-sigs/ip-masq-agent/issues/76.

/cc @jingyuanliang 