### PR TITLE
Switch base image to k8s.gcr.io/build-image/distroless-iptables:v0.1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ HTTPS_PROXY ?=
 OS := $(if $(GOOS),$(GOOS),$(shell go env GOOS))
 ARCH := $(if $(GOARCH),$(GOARCH),$(shell go env GOARCH))
 
-BASEIMAGE ?= k8s.gcr.io/build-image/debian-iptables:bullseye-v1.5.0
+BASEIMAGE ?= k8s.gcr.io/build-image/distroless-iptables:v0.1.1
 
 TAG := $(VERSION)__$(OS)_$(ARCH)
 

--- a/ip-masq-agent.yaml
+++ b/ip-masq-agent.yaml
@@ -15,7 +15,7 @@ spec:
       hostNetwork: true
       containers:
       - name: ip-masq-agent
-        image: k8s.gcr.io/networking/ip-masq-agent:v2.7.1
+        image: k8s.gcr.io/networking/ip-masq-agent:v2.8.0
         securityContext:
           privileged: false
           capabilities:


### PR DESCRIPTION
Also incorporated buildx from GoogleCloudPlatform/netd@cf82473 which should fix the `exec format error` for non-AMD64 images.

/assign @MrHohn 
/hold