### PR TITLE
increase cidr limit from 64 to 128

### DIFF
--- a/cmd/ip-masq-agent/ip-masq-agent.go
+++ b/cmd/ip-masq-agent/ip-masq-agent.go
@@ -222,10 +222,10 @@ func (m *MasqDaemon) syncConfig(fs fakefs.FileSystem) error {
 }
 
 func (c *MasqConfig) validate() error {
-	// limit to 64 CIDRs (excluding link-local) to protect against really bad mistakes
+	// limit to 128 CIDRs (excluding link-local) to protect against really bad mistakes
 	n := len(c.NonMasqueradeCIDRs)
-	if n > 64 {
-		return fmt.Errorf("the daemon can only accept up to 64 CIDRs (excluding link-local), but got %d CIDRs (excluding link local)", n)
+	if n > 128 {
+		return fmt.Errorf("the daemon can only accept up to 128 CIDRs (excluding link-local), but got %d CIDRs (excluding link local)", n)
 	}
 	// check CIDRs are valid
 	for _, cidr := range c.NonMasqueradeCIDRs {


### PR DESCRIPTION
We use the ip-masq-agent for overriding the default masquerading for several endpoints. The CIDR limit is arbitrarily low see https://github.com/kubernetes-sigs/ip-masq-agent/pull/8#discussion_r232398808, I've bumped it to 128 here but would a variable configuration in the configmap be accepted if I updated?