### PR TITLE
Bump go version to 1.19 to pick up a few CVE fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ BASEIMAGE ?= k8s.gcr.io/build-image/distroless-iptables:v0.1.1
 
 TAG := $(VERSION)__$(OS)_$(ARCH)
 
-BUILD_IMAGE ?= golang:1.17-alpine
+BUILD_IMAGE ?= golang:1.19.4-alpine
 
 BIN_EXTENSION :=
 ifeq ($(OS), windows)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/ip-masq-agent
 
-go 1.17
+go 1.19
 
 require (
 	github.com/golang/glog v1.0.0


### PR DESCRIPTION
/assign @jingyuanliang 

Ref https://github.com/kubernetes-sigs/ip-masq-agent/issues/94 - we will likely abadon v2.9.0 and make a v2.9.1 after this.

Fixes https://github.com/kubernetes-sigs/ip-masq-agent/issues/96.