### PR TITLE
add .buildx-initalized to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /.container-*
 /.dockerfile-*
 /.licenses
+/.buildx-initialized
 
 # Emacs save files
 *~


### PR DESCRIPTION
`make container` generates `.buildx-initalized` file. adding to gitignore to avoid non-clean git state