### PR TITLE
Replace k8s.gcr.io with registry.k8s.io

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,7 @@ The ip-masq-agent is released on an as-needed basis. The process is as follows:
 1. The release issue is closed.
 1. An announcement email is sent to `kubernetes-dev@googlegroups.com` with the subject `[ANNOUNCE] ip-masq-agent vx.x.x is released`.
 1. Propose a PR to k8s.io/k8s.gcr.io/images/k8s-staging-networking/images.yaml to add the new image to be promoted.
-1. Look for the final image to be available at k8s.gcr.io/networking/ip-masq-agent-*
+1. Look for the final image to be available at registry.k8s.io/networking/ip-masq-agent-*
 
 Example:
 

--- a/ip-masq-agent.yaml
+++ b/ip-masq-agent.yaml
@@ -15,7 +15,7 @@ spec:
       hostNetwork: true
       containers:
       - name: ip-masq-agent
-        image: k8s.gcr.io/networking/ip-masq-agent:v2.8.0
+        image: registry.k8s.io/networking/ip-masq-agent:v2.8.0
         securityContext:
           privileged: false
           capabilities:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR replaces all `k8s.gcr.io` references with `registry.k8s.io`. See the linked issue for more details.

**Which issue(s) this PR fixes**:
xref https://github.com/kubernetes/k8s.io/issues/4738

**Release note**:
```
Replace all `k8s.gcr.io` references with `registry.k8s.io`
```