### PR TITLE
Remove GO_VERSION test matrix

### DIFF
--- a/.github/workflows/crossbuild.yaml
+++ b/.github/workflows/crossbuild.yaml
@@ -6,11 +6,10 @@ jobs:
   crossbuild:
     strategy:
       matrix:
-        go-version: [ "1.20", "1.21", "1.22" ]
         platform: [ "ubuntu-latest" ]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Build containers
-      run: make all-container GO_VERSION=${{ matrix.go-version }}
+      run: make all-container

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,11 +6,10 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [ "1.21", "1.22" ]
         platform: [ "ubuntu-latest" ]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Test
-      run: make test GOFLAGS="-v" GO_VERSION=${{ matrix.go-version }}
+      run: make test GOFLAGS="-v"


### PR DESCRIPTION
We'll have to keep go version in go.mod at the latest, to ensure golang compatibility support throughout the release lifetime. However this breaks buildability with older golang images, since Go 1.21.

/assign @MrHohn 