### PR TITLE
add --to-ports 32768-65535 to avoid overlapping with nodeport range

### DIFF
--- a/cmd/ip-masq-agent/ip-masq-agent.go
+++ b/cmd/ip-masq-agent/ip-masq-agent.go
@@ -386,7 +386,7 @@ func writeNonMasqRule(lines *bytes.Buffer, cidr string) {
 const masqRuleComment = `-m comment --comment "ip-masq-agent: outbound traffic is subject to MASQUERADE (must be last in chain)"`
 
 func writeMasqRule(lines *bytes.Buffer) {
-	args := []string{masqRuleComment, "-j", "MASQUERADE"}
+	args := []string{masqRuleComment, "-j", "MASQUERADE", "--to-ports", "32768-65535"}
 	if *randomFully {
 		args = append(args, "--random-fully")
 	}

--- a/cmd/ip-masq-agent/ip-masq-agent_test.go
+++ b/cmd/ip-masq-agent/ip-masq-agent_test.go
@@ -310,7 +310,7 @@ func TestSyncMasqRules(t *testing.T) {
 -A ` + string(utiliptables.ChainPostrouting) + ` -m comment --comment ` +
 				fmt.Sprintf(postRoutingMasqChainCommentFormat, masqChain) + ` -m addrtype ! --dst-type LOCAL -j ` + string(masqChain) + `
 -A ` + string(masqChain) + ` ` + nonMasqRuleComment + ` -d 169.254.0.0/16 -j RETURN
--A ` + string(masqChain) + ` ` + masqRuleComment + ` -j MASQUERADE` + wantRandomFully + `
+-A ` + string(masqChain) + ` ` + masqRuleComment + ` -j MASQUERADE --to-ports 32768-65535` + wantRandomFully + `
 COMMIT
 `,
 		},
@@ -326,7 +326,7 @@ COMMIT
 -A ` + string(masqChain) + ` ` + nonMasqRuleComment + ` -d 10.0.0.0/8 -j RETURN
 -A ` + string(masqChain) + ` ` + nonMasqRuleComment + ` -d 172.16.0.0/12 -j RETURN
 -A ` + string(masqChain) + ` ` + nonMasqRuleComment + ` -d 192.168.0.0/16 -j RETURN
--A ` + string(masqChain) + ` ` + masqRuleComment + ` -j MASQUERADE` + wantRandomFully + `
+-A ` + string(masqChain) + ` ` + masqRuleComment + ` -j MASQUERADE --to-ports 32768-65535` + wantRandomFully + `
 COMMIT
 `,
 		},
@@ -350,7 +350,7 @@ COMMIT
 -A ` + string(masqChain) + ` ` + nonMasqRuleComment + ` -d 198.51.100.0/24 -j RETURN
 -A ` + string(masqChain) + ` ` + nonMasqRuleComment + ` -d 203.0.113.0/24 -j RETURN
 -A ` + string(masqChain) + ` ` + nonMasqRuleComment + ` -d 240.0.0.0/4 -j RETURN
--A ` + string(masqChain) + ` ` + masqRuleComment + ` -j MASQUERADE` + wantRandomFully + `
+-A ` + string(masqChain) + ` ` + masqRuleComment + ` -j MASQUERADE --to-ports 32768-65535` + wantRandomFully + `
 COMMIT
 `,
 		},
@@ -369,7 +369,7 @@ COMMIT
 				fmt.Sprintf(postRoutingMasqChainCommentFormat, masqChain) + ` -m addrtype ! --dst-type LOCAL -j ` + string(masqChain) + `
 -A ` + string(masqChain) + ` ` + nonMasqRuleComment + ` -d 169.254.0.0/16 -j RETURN
 -A ` + string(masqChain) + ` ` + nonMasqRuleComment + ` -d 10.244.0.0/16 -j RETURN
--A ` + string(masqChain) + ` ` + masqRuleComment + ` -j MASQUERADE` + wantRandomFully + `
+-A ` + string(masqChain) + ` ` + masqRuleComment + ` -j MASQUERADE --to-ports 32768-65535` + wantRandomFully + `
 COMMIT
 `,
 		},
@@ -411,7 +411,7 @@ func TestSyncMasqRulesIPv6(t *testing.T) {
 -A ` + string(utiliptables.ChainPostrouting) + ` -m comment --comment ` +
 				fmt.Sprintf(postRoutingMasqChainCommentFormat, masqChain) + ` -m addrtype ! --dst-type LOCAL -j ` + string(masqChain) + `
 -A ` + string(masqChain) + ` ` + nonMasqRuleComment + ` -d fe80::/10 -j RETURN
--A ` + string(masqChain) + ` ` + masqRuleComment + ` -j MASQUERADE` + wantRandomFully + `
+-A ` + string(masqChain) + ` ` + masqRuleComment + ` -j MASQUERADE --to-ports 32768-65535` + wantRandomFully + `
 COMMIT
 `,
 		},
@@ -430,7 +430,7 @@ COMMIT
 				fmt.Sprintf(postRoutingMasqChainCommentFormat, masqChain) + ` -m addrtype ! --dst-type LOCAL -j ` + string(masqChain) + `
 -A ` + string(masqChain) + ` ` + nonMasqRuleComment + ` -d fe80::/10 -j RETURN
 -A ` + string(masqChain) + ` ` + nonMasqRuleComment + ` -d fc00::/7 -j RETURN
--A ` + string(masqChain) + ` ` + masqRuleComment + ` -j MASQUERADE` + wantRandomFully + `
+-A ` + string(masqChain) + ` ` + masqRuleComment + ` -j MASQUERADE --to-ports 32768-65535` + wantRandomFully + `
 COMMIT
 `,
 		},
@@ -442,7 +442,7 @@ COMMIT
 :` + string(masqChain) + ` - [0:0]
 -A ` + string(utiliptables.ChainPostrouting) + ` -m comment --comment ` +
 				fmt.Sprintf(postRoutingMasqChainCommentFormat, masqChain) + ` -m addrtype ! --dst-type LOCAL -j ` + string(masqChain) + `
--A ` + string(masqChain) + ` ` + masqRuleComment + ` -j MASQUERADE` + wantRandomFully + `
+-A ` + string(masqChain) + ` ` + masqRuleComment + ` -j MASQUERADE --to-ports 32768-65535` + wantRandomFully + `
 COMMIT
 `,
 		},


### PR DESCRIPTION
Google DPv2 engineer jingyuanliang suggested trying https://github.com/jingyuanliang/ip-masq-agent/commit/d7f91b2f4c16f874a45a8cb90a019f39930a066e to avoid using the nodeport ranges for outbound connections.

ref: https://github.com/Shopify/cloud-systems/issues/1388