### PR TITLE
Replace comment that's no longer relevant

### DIFF
--- a/cmd/ip-masq-agent/ip-masq-agent.go
+++ b/cmd/ip-masq-agent/ip-masq-agent.go
@@ -393,11 +393,10 @@ func (m *MasqDaemon) syncMasqRulesIPv6() error {
 	return nil
 }
 
-// NOTE(mtaufen): iptables requires names to be <= 28 characters, and somehow prepending "-m comment --comment " to this string makes it think this condition is violated
-// Feel free to dig around in iptables and see if you can figure out exactly why; I haven't had time to fully trace how it parses and handle subcommands.
-// If you want to investigate, get the source via `git clone git://git.netfilter.org/iptables.git`, `git checkout v1.4.21` (the version I've seen this issue on,
-// though it may also happen on others), and start with `git grep XT_EXTENSION_MAXNAMELEN`.
-const postRoutingMasqChainCommentFormat = "\"ip-masq-agent: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom %s chain\""
+// Unlike nonMasqRuleComment and masqRuleComment, this variable is not used to build a buffer
+// for RestoreAll, but used with EnsureRule where it's directly passed in as an argument to the
+// iptables command after "--comment", thus only one argument is possible with no quote needed.
+const postRoutingMasqChainCommentFormat = "ip-masq-agent: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom %s chain"
 
 func postroutingJumpComment() string {
 	return fmt.Sprintf(postRoutingMasqChainCommentFormat, masqChain)


### PR DESCRIPTION
I believe the original issue occurred because the whole (after "-m")
" comment --comment ..." string was parsed as the module name (in place
of "comment"). It's not possible to put unparsed string in the args,
because it doesn't go through a shell.

Also removed the unnecessary quote; I think it was there because we
assumed it's passing through the shell (so that words get split).


/assign @MrHohn @mtaufen