### PR TITLE
Fixing broken github workflows

### DIFF
--- a/.github/workflows/crossbuild.yaml
+++ b/.github/workflows/crossbuild.yaml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Build containers
       run: make all-container

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Lint
       run: make lint

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Test
       run: make test GOFLAGS="-v"


### PR DESCRIPTION
Ref https://github.com/kubernetes-sigs/ip-masq-agent/pull/214 - github workflows are failing with a similar error: https://github.com/kubernetes-sigs/ip-masq-agent/actions/runs/27304147270/job/80658121868?pr=214
```
Current runner version: '2.335.1'
Runner Image Provisioner
Operating System
Runner Image
GITHUB_TOKEN Permissions
Secret source: None
Prepare workflow directory
Prepare all required actions
Getting action download info
Error: The action actions/checkout@v3 is not allowed in kubernetes-sigs/ip-masq-agent because all actions must be pinned to a full-length commit SHA.
```

This PR pin checkout action to immutable SHA.

@jingyuanliang @vbannai